### PR TITLE
Add ability to toggle flashlight.

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -20,8 +20,42 @@ import org.asteroid.controls 1.0
 import Nemo.KeepAlive 1.1
 
 Application {
-    centerColor: "#fff"
-    outerColor: "#fff"
+    centerColor: "#b04d1c"
+    outerColor: "#421c0a"
 
+    Rectangle {
+        id: whiteOverlay
+        color: "#fff"
+        anchors.fill: parent
+        OpacityAnimator {
+            id: onOffAnimation
+            target: whiteOverlay
+            to: 1
+            duration: 100
+        }
+    }
+
+    Icon {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        width: Dims.l(20)
+        height: width
+        name:  "ios-bulb"
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            if (onOffAnimation.to == 1) {
+                onOffAnimation.from = 1
+                onOffAnimation.to = 0
+                onOffAnimation.start()
+            } else {
+                onOffAnimation.from = 0
+                onOffAnimation.to = 1
+                onOffAnimation.start()
+            }
+        }
+    }
     Component.onCompleted: DisplayBlanking.preventBlanking = true
 }


### PR DESCRIPTION
The flashlight app does not have an obvious way to close. This adds the tap-to-off feature.

The `off` screen looks a bit empty without any content shown, so I added a simple flashlight icon:
![flashlight](https://user-images.githubusercontent.com/7857908/79005743-d4c0d580-7b57-11ea-8860-b47a3f72091b.jpg)

Also, instead of immediate transitioning from off to on and visa versa a simple short opacity transition is added.

Any suggestions are welcome!

This may be a possible implementation of https://github.com/AsteroidOS/asteroid-flashlight/issues/1