### PR TITLE
Fix positioning on non-square devices

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -31,9 +31,10 @@ Application {
         property bool flashOn: true
 
         anchors.centerIn: parent
+        anchors.verticalCenterOffset: DeviceInfo.flatTireHeight/2
         color: flashOn ? "#ffffffff" : "#66444444"
         width: flashOn ? Dims.w(100) : Dims.w(45)
-        height: width
+        height: flashOn ? Dims.h(100) : width
         radius: DeviceInfo.hasRoundScreen ? width : flashOn ? 0 : width
 
         Icon {
@@ -50,6 +51,7 @@ Application {
         }
 
         Behavior on width { NumberAnimation { duration: 100; easing.type: Easing.InCurve } }
+        Behavior on height { NumberAnimation { duration: 100; easing.type: Easing.InCurve } }
         Behavior on radius { NumberAnimation { duration: 100; easing.type: Easing.OutQuint } }
         Behavior on color { ColorAnimation { duration: 150; easing.type: Easing.InCurve } }
     }


### PR DESCRIPTION
This should fix the flashlight issues on flat tyres (where flatmesh would be visible at the bottom of the display due to the flashlight not being centered correctly) and on non-square watches (currently beluga, where the flashlight would not fill the entire display as it assumed all displays were square). Currently a draft, as I have tested it to be working on ayu (a flat tyre) but testing is still needed on beluga