### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ include(AsteroidTranslations)
 
 ecm_find_qmlmodule(Nemo.KeepAlive 1.1)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-flashlight.in
+	${CMAKE_BINARY_DIR}/asteroid-flashlight
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-flashlight
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 add_subdirectory(src)
 

--- a/asteroid-flashlight.desktop.template
+++ b/asteroid-flashlight.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-flashlight
+Exec=asteroid-flashlight
 Icon=ios-bulb-outline
 X-Asteroid-Center-Color=#00A698
 X-Asteroid-Outer-Color=#000C07

--- a/asteroid-flashlight.in
+++ b/asteroid-flashlight.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-flashlight.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-flashlight main.cpp resources.qrc)
-set_target_properties(asteroid-flashlight PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-flashlight PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-flashlight PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-flashlight
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker